### PR TITLE
Escaped labels

### DIFF
--- a/src/AFSDBRecord.cs
+++ b/src/AFSDBRecord.cs
@@ -37,7 +37,7 @@ namespace Makaretu.Dns
         /// <value>
         ///   The name of an AFS server.
         /// </value>
-        public string Target { get; set; }
+        public DomainName Target { get; set; }
 
 
         /// <inheritdoc />

--- a/src/AddressRecord.cs
+++ b/src/AddressRecord.cs
@@ -41,7 +41,7 @@ namespace Makaretu.Dns
         ///   An <see cref="ARecord"/> or <see cref="AAAARecord"/> tha describes
         ///   the <paramref name="name"/> and <paramref name="address"/>.
         /// </returns>
-        public static AddressRecord Create(string name, IPAddress address)
+        public static AddressRecord Create(DomainName name, IPAddress address)
         {
             if (address.AddressFamily == AddressFamily.InterNetwork)
             {

--- a/src/CNAMERecord.cs
+++ b/src/CNAMERecord.cs
@@ -28,7 +28,7 @@ namespace Makaretu.Dns
         ///  A domain-name which specifies the canonical or primary
         ///  name for the owner. The owner name is an alias.
         /// </summary>
-        public string Target { get; set; }
+        public DomainName Target { get; set; }
 
 
         /// <inheritdoc />

--- a/src/DNAMERecord.cs
+++ b/src/DNAMERecord.cs
@@ -28,7 +28,7 @@ namespace Makaretu.Dns
         ///  A domain-name which specifies the canonical or primary
         ///  name for the owner. The owner name is an alias.
         /// </summary>
-        public string Target { get; set; }
+        public DomainName Target { get; set; }
 
 
         /// <inheritdoc />

--- a/src/DSRecord.cs
+++ b/src/DSRecord.cs
@@ -50,8 +50,8 @@ namespace Makaretu.Dns
                     throw new ArgumentException("ZoneKey must be set.", "key");
                 if ((key.Flags & DNSKEYFlags.SecureEntryPoint) == DNSKEYFlags.None)
                     throw new ArgumentException("SecureEntryPoint must be set.", "key");
-                if (string.IsNullOrWhiteSpace(key.Name))
-                    throw new ArgumentOutOfRangeException("The name is missing.", "key");
+                if (string.IsNullOrWhiteSpace(key.Name.ToString()))
+                    throw new ArgumentOutOfRangeException("The key name is missing.", "key");
             }
 
             byte[] digest;

--- a/src/DSRecord.cs
+++ b/src/DSRecord.cs
@@ -50,8 +50,6 @@ namespace Makaretu.Dns
                     throw new ArgumentException("ZoneKey must be set.", "key");
                 if ((key.Flags & DNSKEYFlags.SecureEntryPoint) == DNSKEYFlags.None)
                     throw new ArgumentException("SecureEntryPoint must be set.", "key");
-                if (string.IsNullOrWhiteSpace(key.Name.ToString()))
-                    throw new ArgumentOutOfRangeException("The key name is missing.", "key");
             }
 
             byte[] digest;

--- a/src/Dns.csproj
+++ b/src/Dns.csproj
@@ -8,8 +8,8 @@
     <DebugType>full</DebugType>
     
     <!-- developer build is always 0.42 -->
-    <AssemblyVersion>0.42</AssemblyVersion>
-    <Version>0.42</Version>
+    <AssemblyVersion>0.42.1</AssemblyVersion>
+    <Version>0.42.1</Version>
     
     <!-- Nuget specs -->
     <PackageId>Makaretu.Dns</PackageId>
@@ -18,7 +18,7 @@
     <Description>DNS data model with serializer/deserializer for the wire and master file format.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>https://github.com/richardschneider/net-dns/releases</PackageReleaseNotes>
-    <Copyright>© 2018 Richard Schneider</Copyright>
+    <Copyright>© 2018-2019 Richard Schneider</Copyright>
     <PackageTags>dns</PackageTags>
     <IncludeSymbols>True</IncludeSymbols>
     <PackageLicenseUrl>https://github.com/richardschneider/net-dns/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Dns.csproj
+++ b/src/Dns.csproj
@@ -6,7 +6,8 @@
     <RootNamespace>Makaretu.Dns</RootNamespace>
     <DocumentationFile>Makaretu.Dns.xml</DocumentationFile>
     <DebugType>full</DebugType>
-    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
     <!-- developer build is always 0.42 -->
     <AssemblyVersion>0.42.1</AssemblyVersion>
     <Version>0.42.1</Version>

--- a/src/DnsObject.cs
+++ b/src/DnsObject.cs
@@ -154,25 +154,5 @@ namespace Makaretu.Dns
         /// <inheritdoc />
         public abstract void Write(WireWriter writer);
 
-        /// <summary>
-        ///   Determines if the two domain names are equal.
-        /// </summary>
-        /// <param name="a">A domain name</param>
-        /// <param name="b">A domain name</param>
-        /// <returns>
-        ///   <b>true</b> if <paramref name="a"/> and <paramref name="b"/> are
-        ///   considered equal.
-        /// </returns>
-        /// <remarks>
-        ///   Uses a case-insenstive algorithm, where 'A-Z' are equivalent to 'a-z'.
-        /// </remarks>
-        public static bool NamesEquals(string a, string b)
-        {
-#if NETSTANDARD14
-            return a?.ToLowerInvariant() == b?.ToLowerInvariant();
-#else
-            return 0 == StringComparer.InvariantCultureIgnoreCase.Compare(a, b);
-#endif
-        }
     }
 }

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -76,6 +76,25 @@ namespace Makaretu.Dns
             return string.Join(dot, Labels.Select(label => label.Replace(dot, escapedDot)));
         }
 
+        /// <summary>
+        ///   Gets the canonical form of the domain name.
+        /// </summary>
+        /// <returns>
+        ///   A domain name in the canonical form.
+        /// </returns>
+        /// <remarks>
+        ///   All uppercase US-ASCII letters in the <see cref="Labels"/> are
+        ///   replaced by the corresponding lowercase US-ASCII letters.
+        /// </remarks>
+        public DomainName ToCanonical()
+        {
+            var labels = Labels
+                .Select(l => l.ToLowerInvariant())
+                .ToArray();
+            return new DomainName(labels);
+        }
+
+
         void Parse(string name)
         {
             Labels.Clear();

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -97,6 +97,54 @@ namespace Makaretu.Dns
             return new DomainName(labels);
         }
 
+        /// <summary>
+        ///   Determines if this domain name is a subdomain of another
+        ///   domain name.
+        /// </summary>
+        /// <param name="domain">
+        ///   Another domain.
+        /// </param>
+        /// <returns>
+        ///   <b>true</b> if this domain name is a subdomain of <paramref name="domain"/>.
+        /// </returns>
+        public bool IsSubdomain(DomainName domain)
+        {
+            if (domain == null)
+            {
+                return false;
+            }
+            if (Labels.Count <= domain.Labels.Count)
+            {
+                return false;
+            }
+            var i = Labels.Count - 1;
+            var j = domain.Labels.Count - 1;
+            for (; 0 <= j; --i, --j)
+            {
+                if (!DnsObject.NamesEquals(Labels[i], domain.Labels[j]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///   Gets the parent's domain name.
+        /// </summary>
+        /// <returns>
+        ///   The domain name of the parent or <b>null</b> if
+        ///   there is no parent; e.g. this is the root.
+        /// </returns>
+        public DomainName Parent()
+        {
+            if (Labels.Count == 0)
+            {
+                return null;
+            }
+
+            return new DomainName(Labels.Skip(1).ToArray());
+        }
 
         void Parse(string name)
         {

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -291,6 +291,10 @@ namespace Makaretu.Dns
         /// <inheritdoc />
         public bool Equals(DomainName that)
         {
+            if (that is null)
+            {
+                return false;
+            }
             var n = this.labels.Count;
             if (n != that.labels.Count)
             {

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -18,6 +18,8 @@ namespace Makaretu.Dns
         const string dot = ".";
         const char dotChar = '.';
         const string escapedDot = @"\.";
+        const string backslash = @"\";
+        const string escapedBackslash = @"\092";
 
         /// <summary>
         ///   The root name space.
@@ -107,11 +109,13 @@ namespace Makaretu.Dns
         ///   The concatenation of the <see cref="Labels"/> separated by a dot.
         /// </returns>
         /// <remarks>
-        ///   If a label contains a dot, then it is escaped with a backslash.
+        ///   If a label contains a dot or backslash, then it is escaped with a backslash.
         /// </remarks>
         public override string ToString()
         {
-            return string.Join(dot, Labels.Select(label => label.Replace(dot, escapedDot)));
+            return string.Join(dot, Labels.Select(label => label
+                .Replace(backslash, escapedBackslash)
+                .Replace(dot, escapedDot)));
         }
 
         /// <summary>

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,6 +20,7 @@ namespace Makaretu.Dns
         const char dotChar = '.';
         const string escapedDot = @"\.";
         const string backslash = @"\";
+        const char backslashChar = '\\';
         const string escapedBackslash = @"\092";
 
         /// <summary>
@@ -113,9 +115,34 @@ namespace Makaretu.Dns
         /// </remarks>
         public override string ToString()
         {
-            return string.Join(dot, Labels.Select(label => label
-                .Replace(backslash, escapedBackslash)
-                .Replace(dot, escapedDot)));
+            return string.Join(dot, Labels.Select(EscapeLabel));
+        }
+
+        string EscapeLabel(string label)
+        {
+            var sb = new StringBuilder();
+            foreach (var c in label)
+            {
+                if (c == backslashChar)
+                {
+                    sb.Append(escapedBackslash);
+                }
+                else if (c == dotChar)
+                {
+                    sb.Append(escapedDot);
+                }
+                else if (c <= 32 || c > 0x7E)
+                {
+                    sb.Append(backslashChar);
+                    sb.Append(((int)c).ToString("000", CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -11,7 +11,7 @@ namespace Makaretu.Dns
     /// conventionally delimited by dots, such as "example.org".
     /// </summary>
     /// <remarks>
-    ///   Equality is based on the number of and contents of <see cref="Labels"/>.
+    ///   Equality is based on the number of and the case-insenstive contents of <see cref="Labels"/>.
     /// </remarks>
     public class DomainName : IEquatable<DomainName>
     {
@@ -124,7 +124,7 @@ namespace Makaretu.Dns
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return ToString().GetHashCode();
+            return ToString().ToLowerInvariant().GetHashCode();
         }
 
         /// <inheritdoc />
@@ -146,7 +146,7 @@ namespace Makaretu.Dns
             }
             for (var i = 0; i < n; ++i)
             {
-                if (this.Labels[i] != that.Labels[i])
+                if (!DnsObject.NamesEquals(this.Labels[i], that.Labels[i]))
                 {
                     return false;
                 }

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -203,7 +203,7 @@ namespace Makaretu.Dns
             var j = domain.labels.Count - 1;
             for (; 0 <= j; --i, --j)
             {
-                if (!DnsObject.NamesEquals(labels[i], domain.labels[j]))
+                if (!LabelsEqual(labels[i], domain.labels[j]))
                 {
                     return false;
                 }
@@ -298,7 +298,7 @@ namespace Makaretu.Dns
             }
             for (var i = 0; i < n; ++i)
             {
-                if (!DnsObject.NamesEquals(this.labels[i], that.labels[i]))
+                if (!LabelsEqual(this.labels[i], that.labels[i]))
                 {
                     return false;
                 }
@@ -338,9 +338,30 @@ namespace Makaretu.Dns
         /// <remarks>
         ///    Equivalent to <code>new DomainName(s)</code>
         /// </remarks>
-        static public implicit operator DomainName(string s)
+        public static implicit operator DomainName(string s)
         {
             return new DomainName(s);
+        }
+
+        /// <summary>
+        ///   Determines if the two domain name labels are equal.
+        /// </summary>
+        /// <param name="a">A domain name label</param>
+        /// <param name="b">A domain name label</param>
+        /// <returns>
+        ///   <b>true</b> if <paramref name="a"/> and <paramref name="b"/> are
+        ///   considered equal.
+        /// </returns>
+        /// <remarks>
+        ///   Uses a case-insenstive algorithm, where 'A-Z' are equivalent to 'a-z'.
+        /// </remarks>
+        public static bool LabelsEqual(string a, string b)
+        {
+#if NETSTANDARD14
+            return a?.ToLowerInvariant() == b?.ToLowerInvariant();
+#else
+            return 0 == StringComparer.InvariantCultureIgnoreCase.Compare(a, b);
+#endif
         }
 
     }

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Makaretu.Dns
+{
+    /// <summary>
+    /// A domain name consists of one or more parts, <see cref="Labels"/>, that are 
+    /// conventionally delimited by dots, such as "example.org".
+    /// </summary>
+    /// <remarks>
+    ///   Equality is based on the number of and contents of <see cref="Labels"/>.
+    /// </remarks>
+    public class DomainName : IEquatable<DomainName>
+    {
+        const string dot = ".";
+        const char dotChar = '.';
+        const string escapedDot = @"\.";
+
+        /// <summary>
+        ///   A sequence of labels that make up the domain name.
+        /// </summary>
+        /// <value>
+        ///   A sequece of strings.
+        /// </value>
+        /// <remarks>
+        ///   The last label is the TLD (top level domain).
+        /// </remarks>
+        public List<string> Labels { get; set; } = new List<string>();
+
+        /// <summary>
+        ///   Creates a new instance of the <see cref="DomainName"/> class from
+        ///   the specified name.
+        /// </summary>
+        /// <param name="name">
+        ///   The dot separated labels; such as "example.org".
+        /// </param>
+        /// <remarks>
+        ///   The name can contain backslash to escape a character.
+        ///   See <see href="https://tools.ietf.org/html/rfc4343">RFC 4343</see> 
+        ///   for the character escaping rules.
+        /// </remarks>
+        public DomainName(string name)
+        {
+            Parse(name);
+        }
+
+        /// <summary>
+        ///   Creates a new instance of the <see cref="DomainName"/> class from
+        ///   the sequence of label.
+        /// </summary>
+        /// <param name="labels">
+        ///   The <see cref="Labels"/>.
+        /// </param>
+        /// <remarks>
+        ///   The labels are not parsed; character escaping is not performed.
+        /// </remarks>
+        public DomainName(params string[] labels)
+        {
+            Labels.AddRange(labels);
+        }
+
+        /// <summary>
+        ///   Returns the textual representation.
+        /// </summary>
+        /// <returns>
+        ///   The concatenation of the <see cref="Labels"/> separated by a dot.
+        /// </returns>
+        /// <remarks>
+        ///   If a label contains a dot, then it is escaped with a backslash.
+        /// </remarks>
+        public override string ToString()
+        {
+            return string.Join(dot, Labels.Select(label => label.Replace(dot, escapedDot)));
+        }
+
+        void Parse(string name)
+        {
+            Labels.Clear();
+            var label = new StringBuilder();
+            var n = name.Length;
+            for (int i = 0; i < n; ++i)
+            {
+                var c = name[i];
+
+                // An escaped character is either \C or \DDD.
+                if (c == '\\')
+                {
+                    c = name[++i];
+                    if (!char.IsDigit(c))
+                    {
+                        label.Append(c);
+                    }
+                    else
+                    {
+                        var number = c - '0';
+                        number = (number * 10) + (name[++i] - '0');
+                        number = (number * 10) + (name[++i] - '0');
+                        label.Append((char)number);
+                    }
+                    continue;
+                }
+
+                // End of label?
+                if (c == dotChar)
+                {
+                    Labels.Add(label.ToString());
+                    label.Clear();
+                    continue;
+                }
+
+                // Just part of the label.
+                label.Append(c);
+            }
+            if (label.Length > 0)
+            {
+                Labels.Add(label.ToString());
+            }
+
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var that = obj as DomainName;
+            return (that == null)
+               ? false
+               : this.Equals(that);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(DomainName that)
+        {
+            var n = this.Labels.Count;
+            if (n != that.Labels.Count)
+            {
+                return false;
+            }
+            for (var i = 0; i < n; ++i)
+            {
+                if (this.Labels[i] != that.Labels[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///   Value equality.
+        /// </summary>
+        public static bool operator ==(DomainName a, DomainName b)
+        {
+            if (object.ReferenceEquals(a, b)) return true;
+            if (a is null) return false;
+            if (b is null) return false;
+
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        ///   Value inequality.
+        /// </summary>
+        public static bool operator !=(DomainName a, DomainName b)
+        {
+            return !(a == b);
+        }
+
+    }
+}

--- a/src/DomainName.cs
+++ b/src/DomainName.cs
@@ -41,6 +41,9 @@ namespace Makaretu.Dns
         ///   The name can contain backslash to escape a character.
         ///   See <see href="https://tools.ietf.org/html/rfc4343">RFC 4343</see> 
         ///   for the character escaping rules.
+        ///   <note>
+        ///   To use us backslash in a domain name (highly unusaual), you must use a double backslash.
+        ///   </note>
         /// </remarks>
         public DomainName(string name)
         {

--- a/src/MXRecord.cs
+++ b/src/MXRecord.cs
@@ -39,7 +39,7 @@ namespace Makaretu.Dns
         /// <value>
         ///   The name of an mail exchange.
         /// </value>
-        public string Exchange { get; set; }
+        public DomainName Exchange { get; set; }
 
 
         /// <inheritdoc />

--- a/src/NSECRecord.cs
+++ b/src/NSECRecord.cs
@@ -25,9 +25,9 @@ namespace Makaretu.Dns
         ///   delegation point NS RRset
         /// </summary>
         /// <remarks>
-        ///   Defaults to the empty string.
+        ///   Defaults to the <see cref="DomainName.Root"/>.
         /// </remarks>
-        public DomainName NextOwnerName { get; set; } // TODO: = String.Empty;
+        public DomainName NextOwnerName { get; set; } = DomainName.Root;
 
         /// <summary>
         ///   The sequence of RR types present at the NSEC RR's owner name.

--- a/src/NSECRecord.cs
+++ b/src/NSECRecord.cs
@@ -27,7 +27,7 @@ namespace Makaretu.Dns
         /// <remarks>
         ///   Defaults to the empty string.
         /// </remarks>
-        public string NextOwnerName { get; set; } = String.Empty;
+        public DomainName NextOwnerName { get; set; } // TODO: = String.Empty;
 
         /// <summary>
         ///   The sequence of RR types present at the NSEC RR's owner name.

--- a/src/NSRecord.cs
+++ b/src/NSRecord.cs
@@ -35,7 +35,7 @@ namespace Makaretu.Dns
         ///   A domain-name which specifies a host which should be
         ///   authoritative for the specified class and domain.
         /// </summary>
-        public string Authority { get; set; }
+        public DomainName Authority { get; set; }
 
 
         /// <inheritdoc />

--- a/src/OPTRecord.cs
+++ b/src/OPTRecord.cs
@@ -37,7 +37,7 @@ namespace Makaretu.Dns
         public OPTRecord() : base()
         {
             Type = DnsType.OPT;
-            Name = new DomainName("");  // TODO: should we have DomainName.Root?
+            Name = DomainName.Root;
             RequestorPayloadSize = 1280;
             TTL = TimeSpan.Zero;
         }

--- a/src/OPTRecord.cs
+++ b/src/OPTRecord.cs
@@ -37,7 +37,7 @@ namespace Makaretu.Dns
         public OPTRecord() : base()
         {
             Type = DnsType.OPT;
-            Name = "";
+            Name = new DomainName("");  // TODO: should we have DomainName.Root?
             RequestorPayloadSize = 1280;
             TTL = TimeSpan.Zero;
         }

--- a/src/PTRRecord.cs
+++ b/src/PTRRecord.cs
@@ -30,7 +30,7 @@ namespace Makaretu.Dns
         ///  A domain-name which points to some location in the
         ///  domain name space.
         /// </summary>
-        public string DomainName { get; set; }
+        public DomainName DomainName { get; set; }
 
 
         /// <inheritdoc />

--- a/src/PresentationReader.cs
+++ b/src/PresentationReader.cs
@@ -96,19 +96,21 @@ namespace Makaretu.Dns
         /// <returns>
         ///   The domain name as a string.
         /// </returns>
-        public string ReadDomainName()
+        public DomainName ReadDomainName()
         {
             return MakeAbsoluteDomainName(ReadToken());
         }
 
-        string MakeAbsoluteDomainName(string name)
+        DomainName MakeAbsoluteDomainName(string name)
         {
+            // TODO: Needs work with escaping dots.
+
             // If an absolute name.
             if (name.EndsWith("."))
-                return name.Substring(0, name.Length - 1);
+                return new DomainName(name.Substring(0, name.Length - 1));
 
             // Then its a relative name.
-            return (name + "." + Origin).TrimEnd('.');
+            return new DomainName((name + "." + Origin).TrimEnd('.'));
         }
 
         /// <summary>

--- a/src/PresentationReader.cs
+++ b/src/PresentationReader.cs
@@ -455,11 +455,18 @@ namespace Makaretu.Dns
                 {
                     if (ignoreEscape)
                     {
+                        if (sb.Length == 0)
+                        {
+                            tokenStartsNewLine = previousChar == '\r' || previousChar == '\n';
+                        }
                         sb.Append((char)c);
+                        previousChar = c;
+
                         c = text.Read();
                         if (0 <= c)
                         {
                             sb.Append((char)c);
+                            previousChar = c;
                         }
                         continue;
                     }

--- a/src/PresentationReader.cs
+++ b/src/PresentationReader.cs
@@ -17,7 +17,7 @@ namespace Makaretu.Dns
 
         System.IO.TextReader text;
         TimeSpan? defaultTTL = null;
-        string defaultDomainName = null;
+        DomainName defaultDomainName = null;
         int parenLevel = 0;
         int previousChar = '\n';  // Assume a newline
         bool eolSeen = false;
@@ -55,7 +55,7 @@ namespace Makaretu.Dns
         ///   <b>Origin</b> is used when the domain name "@" is used
         ///   for a domain name.
         /// </remarks>
-        public string Origin { get; set; } = String.Empty;
+        public DomainName Origin { get; set; } = DomainName.Root;
 
         /// <summary>
         ///   Read a byte.
@@ -98,19 +98,17 @@ namespace Makaretu.Dns
         /// </returns>
         public DomainName ReadDomainName()
         {
-            return MakeAbsoluteDomainName(ReadToken());
+            return MakeAbsoluteDomainName(ReadToken(ignoreEscape: true));
         }
 
         DomainName MakeAbsoluteDomainName(string name)
         {
-            // TODO: Needs work with escaping dots.
-
             // If an absolute name.
             if (name.EndsWith("."))
                 return new DomainName(name.Substring(0, name.Length - 1));
 
             // Then its a relative name.
-            return new DomainName((name + "." + Origin).TrimEnd('.'));
+            return DomainName.Join(new DomainName(name), Origin);
         }
 
         /// <summary>
@@ -289,14 +287,14 @@ namespace Makaretu.Dns
         /// </remarks>
         public ResourceRecord ReadResourceRecord()
         {
-            string domainName = defaultDomainName;
+            DomainName domainName = defaultDomainName;
             DnsClass klass = DnsClass.IN;
             TimeSpan? ttl = defaultTTL;
             DnsType? type = null;
 
             while (!type.HasValue)
             {
-                var token = ReadToken();
+                var token = ReadToken(ignoreEscape: true);
                 if (token == "")
                 {
                     return null;
@@ -308,7 +306,7 @@ namespace Makaretu.Dns
                     switch (token)
                     {
                         case "$ORIGIN":
-                            Origin = ReadToken();
+                            Origin = ReadDomainName();
                             break;
                         case "$TTL":
                             defaultTTL = ttl = ReadTimeSpan32();
@@ -317,7 +315,8 @@ namespace Makaretu.Dns
                             domainName = Origin;
                             break;
                         default:
-                            domainName = token;
+                            domainName = MakeAbsoluteDomainName(token);
+                            defaultDomainName = domainName;
                             break;
                     }
                     continue;
@@ -357,11 +356,9 @@ namespace Makaretu.Dns
                 throw new InvalidDataException($"Unknown token '{token}', expected a Class, Type or TTL.");
             }
 
-            defaultDomainName = domainName;
-
             // Create the specific resource record based on the type.
             var resource = ResourceRegistry.Create(type.Value);
-            resource.Name = MakeAbsoluteDomainName(domainName);
+            resource.Name = domainName;
             resource.Type = type.Value;
             resource.Class = klass;
             if (ttl.HasValue)
@@ -424,7 +421,7 @@ namespace Makaretu.Dns
             return true;
         }
 
-        string ReadToken()
+        string ReadToken(bool ignoreEscape = false)
         {
             var sb = new StringBuilder();
             int c;
@@ -450,6 +447,16 @@ namespace Makaretu.Dns
                 // Handle escaped character.
                 if (c == '\\')
                 {
+                    if (ignoreEscape)
+                    {
+                        sb.Append((char)c);
+                        c = text.Read();
+                        if (0 <= c)
+                        {
+                            sb.Append((char)c);
+                        }
+                        continue;
+                    }
                     previousChar = c;
 
                     // Handle decimal escapes \DDD

--- a/src/PresentationReader.cs
+++ b/src/PresentationReader.cs
@@ -313,6 +313,7 @@ namespace Makaretu.Dns
                             break;
                         case "@":
                             domainName = Origin;
+                            defaultDomainName = domainName;
                             break;
                         default:
                             domainName = MakeAbsoluteDomainName(token);
@@ -354,6 +355,11 @@ namespace Makaretu.Dns
                 }
 
                 throw new InvalidDataException($"Unknown token '{token}', expected a Class, Type or TTL.");
+            }
+
+            if (domainName == null)
+            { 
+                throw new InvalidDataException("Missing resource record name.");
             }
 
             // Create the specific resource record based on the type.

--- a/src/PresentationReader.cs
+++ b/src/PresentationReader.cs
@@ -452,24 +452,25 @@ namespace Makaretu.Dns
                 {
                     previousChar = c;
 
-                    // Handle octal escapes \DDD
+                    // Handle decimal escapes \DDD
                     int ndigits = 0;
-                    int oc = 0;
-                    for (; ndigits <= 3; ++ndigits) {
+                    int ddd = 0;
+                    for (; ndigits <= 3; ++ndigits)
+                    {
                         c = text.Peek();
-                        if ('0' <= c && c <= '7')
+                        if ('0' <= c && c <= '9')
                         {
                             text.Read();
-                            oc = (oc << 3) | (c - '0');
-                            if (oc > 0x7F)
-                                throw new FormatException("Invalid octal value.");
+                            ddd = (ddd * 10) + (c - '0');
+                            if (ddd > 0xFF)
+                                throw new FormatException("Invalid value.");
                         }
                         else
                         {
                             break;
                         }
                     }
-                    c = (ndigits > 0) ? oc : text.Read();
+                    c = (ndigits > 0) ? ddd : text.Read();
 
                     sb.Append((char)c);
                     skipWhitespace = false;

--- a/src/PresentationWriter.cs
+++ b/src/PresentationWriter.cs
@@ -154,23 +154,9 @@ namespace Makaretu.Dns
         /// <param name="appendSpace">
         ///   Write a space after the value.
         /// </param>
-        public void WriteDomainName(string value, bool appendSpace = true)
-        {
-            WriteString(value, appendSpace);
-        }
-
-        /// <summary>
-        ///   Write a domain name.
-        /// </summary>
-        /// <param name="value">
-        ///   The value to write.
-        /// </param>
-        /// <param name="appendSpace">
-        ///   Write a space after the value.
-        /// </param>
         public void WriteDomainName(DomainName value, bool appendSpace = true)
         {
-            WriteString(value.ToString(), appendSpace);
+            WriteStringUnencoded(value.ToString(), appendSpace);
         }
 
         /// <summary>

--- a/src/PresentationWriter.cs
+++ b/src/PresentationWriter.cs
@@ -160,6 +160,20 @@ namespace Makaretu.Dns
         }
 
         /// <summary>
+        ///   Write a domain name.
+        /// </summary>
+        /// <param name="value">
+        ///   The value to write.
+        /// </param>
+        /// <param name="appendSpace">
+        ///   Write a space after the value.
+        /// </param>
+        public void WriteDomainName(DomainName value, bool appendSpace = true)
+        {
+            WriteString(value.ToString(), appendSpace);
+        }
+
+        /// <summary>
         ///   Write bytes encoded in base-16.
         /// </summary>
         /// <param name="value">

--- a/src/Question.cs
+++ b/src/Question.cs
@@ -12,7 +12,7 @@ namespace Makaretu.Dns
         /// <summary>
         ///    A domain name to query.
         /// </summary>
-        public string Name { get; set; }
+        public DomainName Name { get; set; }
 
         /// <summary>
         ///    A two octet code which specifies the type of the query.

--- a/src/RPRecord.cs
+++ b/src/RPRecord.cs
@@ -27,20 +27,17 @@ namespace Makaretu.Dns
         ///   The mailbox for the responsible person.
         /// </summary>
         /// <value>
-        ///   Defaults to "".
+        ///   Defaults to <see cref="DomainName.Root"/>.
         /// </value>
-        public DomainName Mailbox { get; set; } = new DomainName("");
+        public DomainName Mailbox { get; set; } = DomainName.Root;
 
         /// <summary>
         ///   The name of TXT records for the responsible person.
         /// </summary>
         /// <value>
-        ///   Defaults to "".
+        ///   Defaults to <see cref="DomainName.Root"/>.
         /// </value>
-        /// <remarks>
-        ///   TODO Is this really a domain name>
-        /// </remarks>
-        public DomainName TextName { get; set; } = new DomainName("");
+        public DomainName TextName { get; set; } = DomainName.Root;
 
         /// <inheritdoc />
         public override void ReadData(WireReader reader, int length)

--- a/src/RPRecord.cs
+++ b/src/RPRecord.cs
@@ -29,7 +29,7 @@ namespace Makaretu.Dns
         /// <value>
         ///   Defaults to "".
         /// </value>
-        public string Mailbox { get; set; } = "";
+        public DomainName Mailbox { get; set; } = new DomainName("");
 
         /// <summary>
         ///   The name of TXT records for the responsible person.
@@ -37,7 +37,10 @@ namespace Makaretu.Dns
         /// <value>
         ///   Defaults to "".
         /// </value>
-        public string TextName { get; set; } = "";
+        /// <remarks>
+        ///   TODO Is this really a domain name>
+        /// </remarks>
+        public DomainName TextName { get; set; } = new DomainName("");
 
         /// <inheritdoc />
         public override void ReadData(WireReader reader, int length)

--- a/src/RRSIGRecord.cs
+++ b/src/RRSIGRecord.cs
@@ -87,7 +87,7 @@ namespace Makaretu.Dns
         ///   The owner name of the <see cref="DNSKEYRecord"/> that
         ///   validates the <see cref="Signature"/>.
         /// </summary>
-        public string SignerName { get; set; }
+        public DomainName SignerName { get; set; }
 
         /// <summary>
         ///   The cryptographic signature.

--- a/src/Resolving/NameServer.cs
+++ b/src/Resolving/NameServer.cs
@@ -282,11 +282,12 @@ namespace Makaretu.Dns.Resolving
 
         void FindAddresses(string name, DnsClass klass, Message response)
         {
-            var question = new Question();
-
-            question.Name = name;
-            question.Class = klass;
-            question.Type = DnsType.A;
+            var question = new Question
+            {
+                Name = name,
+                Class = klass,
+                Type = DnsType.A
+            };
             var _ = FindAnswerAsync(question, response, default(CancellationToken)).Result;
 
             question.Type = DnsType.AAAA;

--- a/src/Resolving/NameServer.cs
+++ b/src/Resolving/NameServer.cs
@@ -190,19 +190,17 @@ namespace Makaretu.Dns.Resolving
             return Task.FromResult(false);
         }
 
-        SOARecord FindAuthority(string domainName)
+        SOARecord FindAuthority(DomainName domainName)
         {
             var name = domainName;
-            while (true)
+            while (name != null)
             {
                 if (Catalog.TryGetValue(name, out Node node))
                 {
                     var soa = node.Resources.OfType<SOARecord>().FirstOrDefault();
                     if (soa != null) return soa;
                 }
-                var x = name.IndexOf('.');
-                if (x < 0) break;
-                name = name.Substring(x + 1);
+                name = name.Parent();
             }
 
             return null;
@@ -280,7 +278,7 @@ namespace Makaretu.Dns.Resolving
             }
         }
 
-        void FindAddresses(string name, DnsClass klass, Message response)
+        void FindAddresses(DomainName name, DnsClass klass, Message response)
         {
             var question = new Question
             {

--- a/src/Resolving/Node.cs
+++ b/src/Resolving/Node.cs
@@ -23,12 +23,12 @@ namespace Makaretu.Dns.Resolving
         ///   All <see cref="Resources"/> must have a <see cref="ResourceRecord.Name"/> that
         ///   matches this value.
         /// </remarks>
-        public string Name { get; set; } = string.Empty;
+        public DomainName Name { get; set; } = DomainName.Root;
 
         /// <inheritdoc />
         public override string ToString()
         {
-            return Name;
+            return Name.ToString();
         }
 
         /// <summary>

--- a/src/Resolving/Node.cs
+++ b/src/Resolving/Node.cs
@@ -17,7 +17,7 @@ namespace Makaretu.Dns.Resolving
         ///   The name of the node.
         /// </summary>
         /// <value>
-        ///   An absolute (fully qualified) name.  For example, "emanon.org".
+        ///   An absolute (fully qualified) domain name.  For example, "emanon.org".
         /// </value>
         /// <remarks>
         ///   All <see cref="Resources"/> must have a <see cref="ResourceRecord.Name"/> that

--- a/src/ResourceRecord.cs
+++ b/src/ResourceRecord.cs
@@ -99,7 +99,7 @@ namespace Makaretu.Dns
         /// </returns>
         public bool IsExpired(DateTime? from = null)
         {
-            var now = from.HasValue ? from.Value : DateTime.Now;
+            var now = from ?? DateTime.Now;
             return CreationTime + TTL <= now;
         }
 
@@ -250,9 +250,9 @@ namespace Makaretu.Dns
         /// </remarks>
         public static bool operator ==(ResourceRecord a, ResourceRecord b)
         {
-            if (object.ReferenceEquals(a, b)) return true;
-            if (object.ReferenceEquals(a, null)) return false;
-            if (object.ReferenceEquals(b, null)) return false;
+            if (ReferenceEquals(a, b)) return true;
+            if (ReferenceEquals(a, null)) return false;
+            if (ReferenceEquals(b, null)) return false;
 
             return a.Equals(b);
         }
@@ -268,9 +268,9 @@ namespace Makaretu.Dns
         /// </remarks>
         public static bool operator !=(ResourceRecord a, ResourceRecord b)
         {
-            if (object.ReferenceEquals(a, b)) return false;
-            if (object.ReferenceEquals(a, null)) return true;
-            if (object.ReferenceEquals(b, null)) return true;
+            if (ReferenceEquals(a, b)) return false;
+            if (ReferenceEquals(a, null)) return true;
+            if (ReferenceEquals(b, null)) return true;
 
             return !a.Equals(b);
         }

--- a/src/ResourceRecord.cs
+++ b/src/ResourceRecord.cs
@@ -233,8 +233,6 @@ namespace Makaretu.Dns
             var that = obj as ResourceRecord;
             if (that == null) return false;
 
-            // TODO: Maybe remove NameEquals because we have DomainName.Equals
-            // TODO: remove if (!DnsObject.NamesEquals(this.Name, that.Name)) return false;
             if (this.Name != that.Name) return false;
             if (this.Class != that.Class) return false;
             if (this.Type != that.Type) return false;
@@ -253,9 +251,11 @@ namespace Makaretu.Dns
         /// </remarks>
         public static bool operator ==(ResourceRecord a, ResourceRecord b)
         {
+#pragma warning disable IDE0041 // Null check can be simplified
             if (ReferenceEquals(a, b)) return true;
             if (ReferenceEquals(a, null)) return false;
             if (ReferenceEquals(b, null)) return false;
+#pragma warning restore IDE0041 // Null check can be simplified
 
             return a.Equals(b);
         }
@@ -271,9 +271,11 @@ namespace Makaretu.Dns
         /// </remarks>
         public static bool operator !=(ResourceRecord a, ResourceRecord b)
         {
+#pragma warning disable IDE0041 // Null check can be simplified
             if (ReferenceEquals(a, b)) return false;
             if (ReferenceEquals(a, null)) return true;
             if (ReferenceEquals(b, null)) return true;
+#pragma warning restore IDE0041 // Null check can be simplified
 
             return !a.Equals(b);
         }

--- a/src/ResourceRecord.cs
+++ b/src/ResourceRecord.cs
@@ -41,7 +41,7 @@ namespace Makaretu.Dns
         ///   An owner name, i.e., the name of the node to which this
         ///   resource record pertains.
         /// </summary>
-        public string Name { get; set; }
+        public DomainName Name { get; set; }
 
         /// <summary>
         ///   The canonical form of the owner name.
@@ -52,9 +52,10 @@ namespace Makaretu.Dns
         /// </remarks>
         public string CanonicalName
         {
+            // TOOD: Check usage.  Should not be used because its a string.
             get
             {
-                return Name.ToLowerInvariant();
+                return Name.ToCanonical().ToString();
             }
         }
 
@@ -232,7 +233,9 @@ namespace Makaretu.Dns
             var that = obj as ResourceRecord;
             if (that == null) return false;
 
-            if (!DnsObject.NamesEquals(this.Name, that.Name)) return false;
+            // TODO: Maybe remove NameEquals because we have DomainName.Equals
+            // TODO: remove if (!DnsObject.NamesEquals(this.Name, that.Name)) return false;
+            if (this.Name != that.Name) return false;
             if (this.Class != that.Class) return false;
             if (this.Type != that.Type) return false;
 
@@ -279,7 +282,7 @@ namespace Makaretu.Dns
         public override int GetHashCode()
         {
             return 
-                Name?.ToLowerInvariant().GetHashCode() ?? 0
+                Name?.GetHashCode() ?? 0
                 ^ Class.GetHashCode()
                 ^ Type.GetHashCode()
                 ^ GetData().Aggregate(0, (r, b) => r ^ b.GetHashCode());

--- a/src/SOARecord.cs
+++ b/src/SOARecord.cs
@@ -39,13 +39,13 @@ namespace Makaretu.Dns
         ///  The domain-name of the name server that was the
         ///  original or primary source of data for this zone.
         /// </summary>
-        public string PrimaryName { get; set; }
+        public DomainName PrimaryName { get; set; }
 
         /// <summary>
         ///  A domain-name which specifies the mailbox of the
         ///  person responsible for this zone.
         /// </summary>
-        public string Mailbox { get; set; }
+        public DomainName Mailbox { get; set; }
 
         /// <summary>
         ///  The unsigned 32 bit version number of the original copy

--- a/src/SRVRecord.cs
+++ b/src/SRVRecord.cs
@@ -54,7 +54,7 @@ namespace Makaretu.Dns
         ///   address records for this name, the name MUST NOT be an alias (in
         ///   the sense of RFC 1034 or RFC 2181).
         /// </remarks>
-        public string Target { get; set; }
+        public DomainName Target { get; set; }
 
         /// <inheritdoc />
         public override void ReadData(WireReader reader, int length)

--- a/src/TKEYRecord.cs
+++ b/src/TKEYRecord.cs
@@ -41,7 +41,7 @@ namespace Makaretu.Dns
         ///   using the TKEY RR is actually used to derive the algorithm specific key.
         /// </remarks>
         /// <seealso cref="TSIGRecord.Algorithm"/>
-        public string Algorithm { get; set; }
+        public DomainName Algorithm { get; set; }
 
         /// <summary>
         ///   The start date for the <see cref="Key"/>.

--- a/src/TSIGRecord.cs
+++ b/src/TSIGRecord.cs
@@ -73,7 +73,7 @@ namespace Makaretu.Dns
         /// <value>
         ///   Identifies the HMAC alogirthm.
         /// </value>
-        public string Algorithm { get; set; }
+        public DomainName Algorithm { get; set; }
 
         /// <summary>
         ///   When the record was signed.

--- a/src/UpdatePrerequisiteList.cs
+++ b/src/UpdatePrerequisiteList.cs
@@ -35,7 +35,7 @@ namespace Makaretu.Dns
         ///   condition from that of an actual RR whose RDLENGTH is naturally zero
         ///   (0) (e.g., NULL).  TTL is specified as zero(0).
         /// </remarks>
-        public UpdatePrerequisiteList MustExist(string name, DnsType type)
+        public UpdatePrerequisiteList MustExist(DomainName name, DnsType type)
         {
             var rr = new ResourceRecord
             {
@@ -65,7 +65,7 @@ namespace Makaretu.Dns
         ///   must be specified as ANY to differentiate this case from that of an
         ///   RRset existence test. TTL is specified as zero (0).
         /// </remarks>
-        public UpdatePrerequisiteList MustExist(string name)
+        public UpdatePrerequisiteList MustExist(DomainName name)
         {
             return MustExist(name, DnsType.ANY);
         }
@@ -90,7 +90,7 @@ namespace Makaretu.Dns
         ///   must be specified as ANY to differentiate this case from that of an
         ///   RRset existence test. TTL is specified as zero (0).
         /// </remarks>
-        public UpdatePrerequisiteList MustExist<T>(string name)
+        public UpdatePrerequisiteList MustExist<T>(DomainName name)
             where T : ResourceRecord, new()
         {
             return MustExist(name, new T().Type);
@@ -135,7 +135,7 @@ namespace Makaretu.Dns
         ///   naturally zero (0) (for example, the NULL RR).  TTL must be specified
         ///   as zero(0).
         /// </remarks>
-        public UpdatePrerequisiteList MustNotExist(string name, DnsType type)
+        public UpdatePrerequisiteList MustNotExist(DomainName name, DnsType type)
         {
             var rr = new ResourceRecord
             {
@@ -163,7 +163,7 @@ namespace Makaretu.Dns
         ///   must be specified as NONE. TYPE must be specified as ANY. TTL must
         ///   be specified as zero (0).
         /// </remarks>
-        public UpdatePrerequisiteList MustNotExist(string name)
+        public UpdatePrerequisiteList MustNotExist(DomainName name)
         {
             return MustNotExist(name, DnsType.ANY);
         }
@@ -188,7 +188,7 @@ namespace Makaretu.Dns
         ///   naturally zero (0) (for example, the NULL RR).  TTL must be specified
         ///   as zero(0).
         /// </remarks>
-        public UpdatePrerequisiteList MustNotExist<T>(string name)
+        public UpdatePrerequisiteList MustNotExist<T>(DomainName name)
             where T : ResourceRecord, new()
         {
             return MustNotExist(name, new T().Type);

--- a/src/UpdateResourceList.cs
+++ b/src/UpdateResourceList.cs
@@ -84,7 +84,7 @@ namespace Makaretu.Dns
         ///   this Update RR will be silently ignored by the primary master.
         ///   </para>
         /// </remarks>
-        public UpdateResourceList DeleteResource(string name)
+        public UpdateResourceList DeleteResource(DomainName name)
         {
             var resource = new ResourceRecord
             {
@@ -114,8 +114,8 @@ namespace Makaretu.Dns
         ///   this Update RR will be silently ignored by the primary master.
         ///   </para>
         /// </remarks>
-        /// <seealso cref="DeleteResource{T}(string)"/>
-        public UpdateResourceList DeleteResource(string name, DnsType type)
+        /// <seealso cref="DeleteResource{T}(DomainName)"/>
+        public UpdateResourceList DeleteResource(DomainName name, DnsType type)
         {
             var resource = new ResourceRecord
             {
@@ -147,8 +147,8 @@ namespace Makaretu.Dns
         ///   this Update RR will be silently ignored by the primary master.
         ///   </para>
         /// </remarks>
-        /// <seealso cref="DeleteResource(string, DnsType)"/>
-        public UpdateResourceList DeleteResource<T>(string name)
+        /// <seealso cref="DeleteResource(DomainName, DnsType)"/>
+        public UpdateResourceList DeleteResource<T>(DomainName name)
              where T : ResourceRecord, new()
         {
             return DeleteResource(name, new T().Type);

--- a/src/WireReader.cs
+++ b/src/WireReader.cs
@@ -212,7 +212,7 @@ namespace Makaretu.Dns
                 name = name + "." + remainingLabels;
             }
 
-            // Add to compressed names
+            // Add to compressed names.
             names[pointer] = name;
 
             return name;

--- a/src/WireReader.cs
+++ b/src/WireReader.cs
@@ -162,7 +162,7 @@ namespace Makaretu.Dns
         ///   Read a domain name.
         /// </summary>
         /// <returns>
-        ///   The domain name as a string.
+        ///   The domain name.
         /// </returns>
         /// <exception cref="EndOfStreamException">
         ///   When no more data is available.
@@ -179,11 +179,11 @@ namespace Makaretu.Dns
         ///   Compressed domain names are also supported.
         ///   </note>
         /// </remarks>
-        public string ReadDomainName()
+        public DomainName ReadDomainName()
         {
             var labels = ReadLabels();
             var name = new DomainName(labels.ToArray());
-            return name.ToString();
+            return name;
         }
 
         List<string> ReadLabels()

--- a/src/WireWriter.cs
+++ b/src/WireWriter.cs
@@ -225,15 +225,27 @@ namespace Makaretu.Dns
                 ++Position;
                 return;
             }
+            WriteDomainName(new DomainName(name), uncompressed);
+        }
+
+        public void WriteDomainName(DomainName name, bool uncompressed = false)
+        {
+            if (name == null)
+            {
+                stream.WriteByte(0); // terminating byte
+                ++Position;
+                return;
+            }
 
             if (CanonicalForm)
             {
                 uncompressed = true;
-                name = name.ToLowerInvariant();
+                name = name.ToCanonical();
             }
 
-            var labels = name.Split('.');
-            for (var i = 0; i < labels.Length; ++i)
+            var labels = name.Labels.ToArray();
+            var n = labels.Length;
+            for (var i = 0; i < n; ++i)
             {
                 var label = labels[i];
                 if (label.Length > 63)

--- a/src/WireWriter.cs
+++ b/src/WireWriter.cs
@@ -207,7 +207,7 @@ namespace Makaretu.Dns
         ///   <see cref="CanonicalForm"/> overrides this value.
         /// </param>
         /// <exception cref="ArgumentException">
-        ///   When a label length is greater than 63 or is not ASCII.
+        ///   When a label length is greater than 63 octets.
         /// </exception>
         /// <remarks>
         ///   A domain name is represented as a sequence of labels, where
@@ -228,6 +228,28 @@ namespace Makaretu.Dns
             WriteDomainName(new DomainName(name), uncompressed);
         }
 
+        /// <summary>
+        ///   Write a domain name.
+        /// </summary>
+        /// <param name="name">
+        ///   The name to write.
+        /// </param>
+        /// <param name="uncompressed">
+        ///   Determines if the <paramref name="name"/> must be uncompressed.  The
+        ///   defaultl is false (allow compression).
+        ///   <see cref="CanonicalForm"/> overrides this value.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   When a label length is greater than 63 octets.
+        /// </exception>
+        /// <remarks>
+        ///   A domain name is represented as a sequence of labels, where
+        ///   each label consists of a length octet followed by that
+        ///   number of octets.The domain name terminates with the
+        ///   zero length octet for the null label of the root. Note
+        ///   that this field may be an odd number of octets; no
+        ///   padding is used.
+        /// </remarks>
         public void WriteDomainName(DomainName name, bool uncompressed = false)
         {
             if (name == null)

--- a/test/DSRecordTest.cs
+++ b/test/DSRecordTest.cs
@@ -136,29 +136,5 @@ namespace Makaretu.Dns
             });
         }
 
-        [TestMethod]
-        public void FromDNSKEY_Missing_Name()
-        {
-            var key = new DNSKEYRecord
-            {
-                Name = "  ",
-                Flags = DNSKEYFlags.ZoneKey | DNSKEYFlags.SecureEntryPoint,
-                Algorithm = SecurityAlgorithm.RSASHA1,
-                PublicKey = Convert.FromBase64String(
-                    @"AQOeiiR0GOMYkDshWoSKz9Xz
-                      fwJr1AYtsmx3TGkJaNXVbfi/
-                      2pHm822aJ5iI9BMzNXxeYCmZ
-                      DRD99WYwYqUSdjMmmAphXdvx
-                      egXd/M5+X7OrzKBaMbCVdFLU
-                      Uh6DhweJBjEVv5f2wwjM9Xzc
-                      nOf+EPbtG9DMBmADjFDc2w/r
-                      ljwvFw==")
-            };
-            ExceptionAssert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                var ds = new DSRecord(key);
-            });
-        }
-
     }
 }

--- a/test/DnsObjectTest.cs
+++ b/test/DnsObjectTest.cs
@@ -11,21 +11,6 @@ namespace Makaretu.Dns
     public class DnsObjectTest
     {
         [TestMethod]
-        public void NamesAreCaseInsenstive()
-        {
-            Assert.IsTrue(DnsObject.NamesEquals("fOo", "FoO"));
-            Assert.IsFalse(DnsObject.NamesEquals("foo", "bar"));
-        }
-
-        [TestMethod]
-        public void NamesCanBeNull()
-        {
-            Assert.IsTrue(DnsObject.NamesEquals(null, null));
-            Assert.IsFalse(DnsObject.NamesEquals("foo", null));
-            Assert.IsFalse(DnsObject.NamesEquals(null, "foo"));
-        }
-
-        [TestMethod]
         public void Length_EmptyMessage()
         {
             var message = new Message();

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -225,5 +225,30 @@ namespace Makaretu.Dns
             var b = new DomainName(@"a\0924");
             Assert.AreEqual(a, b);
         }
+
+        [TestMethod]
+        public void Rfc4343_Section_22_SpacesAndDots()
+        {
+            var a = new DomainName(@"Donald\032E\.\032Eastlake\0323rd.example");
+            Assert.AreEqual(2, a.Labels.Count);
+            Assert.AreEqual("Donald E. Eastlake 3rd", a.Labels[0]);
+            Assert.AreEqual("example", a.Labels[1]);
+        }
+
+        [TestMethod]
+        public void Rfc4343_Section_22_Binary()
+        {
+            var a = new DomainName(@"a\000\\\255z.example");
+            Assert.AreEqual(2, a.Labels.Count);
+            Assert.AreEqual('a', a.Labels[0][0]);
+            Assert.AreEqual((char)0, a.Labels[0][1]);
+            Assert.AreEqual('\\', a.Labels[0][2]);
+            Assert.AreEqual((char)0xff, a.Labels[0][3]);
+            Assert.AreEqual('z', a.Labels[0][4]);
+            Assert.AreEqual("example", a.Labels[1]);
+
+            Assert.AreEqual(@"a\000\092\255z.example", a.ToString());
+            Assert.AreEqual(a, new DomainName(a.ToString()));
+        }
     }
 }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -117,5 +117,35 @@ namespace Makaretu.Dns
             Assert.AreEqual("My.EXAMPLe.ORg", a.ToString());
             Assert.AreEqual("my.example.org", a.ToCanonical().ToString());
         }
+
+        [TestMethod]
+        public void IsSubdomain()
+        {
+            var zone = new DomainName("example.org");
+            Assert.IsFalse(zone.IsSubdomain(zone));
+            Assert.IsTrue(new DomainName("a.example.org").IsSubdomain(zone));
+            Assert.IsTrue(new DomainName("a.b.example.org").IsSubdomain(zone));
+            Assert.IsTrue(new DomainName("a.Example.org").IsSubdomain(zone));
+            Assert.IsTrue(new DomainName("a.b.Example.ORG").IsSubdomain(zone));
+            Assert.IsFalse(new DomainName(@"a\.example.org").IsSubdomain(zone));
+            Assert.IsTrue(new DomainName(@"a\.b.example.org").IsSubdomain(zone));
+            Assert.IsTrue(new DomainName(@"a\.b.example.ORG").IsSubdomain(zone));
+            Assert.IsFalse(new DomainName("a.org").IsSubdomain(zone));
+            Assert.IsFalse(new DomainName("a.b.org").IsSubdomain(zone));
+        }
+
+        [TestMethod]
+        public void Parent()
+        {
+            var name = new DomainName(@"a.b\.c.example.org");
+            var expected = new DomainName(@"b\.c.example.org");
+            Assert.AreEqual(expected, name.Parent());
+
+            name = new DomainName("org");
+            expected = new DomainName("");
+            Assert.AreEqual(expected, name.Parent());
+
+            Assert.IsNull(expected.Parent());
+        }
     }
 }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -198,6 +198,32 @@ namespace Makaretu.Dns
             Assert.AreEqual("x", c.Labels[1]);
             Assert.AreEqual("y", c.Labels[2]);
             Assert.AreEqual("z", c.Labels[3]);
-        } 
+        }
+
+        [TestMethod]
+        public void Rfc4343_Section_2()
+        {
+            Assert.AreEqual(new DomainName("foo.example.net."), new DomainName("Foo.ExamplE.net."));
+            Assert.AreEqual(new DomainName("69.2.0.192.in-addr.arpa."), new DomainName("69.2.0.192.in-ADDR.ARPA."));
+        }
+
+        [TestMethod]
+        public void Rfc4343_Section_21_Backslash()
+        {
+            var aslashb = new DomainName(@"a\\b");
+            Assert.AreEqual(1, aslashb.Labels.Count);
+            Assert.AreEqual(@"a\b", aslashb.Labels[0]);
+            Assert.AreEqual(@"a\092b", aslashb.ToString());
+
+            Assert.AreEqual(aslashb, new DomainName(@"a\092b"));
+        }
+
+        [TestMethod]
+        public void Rfc4343_Section_21_4Digits()
+        {
+            var a = new DomainName(@"a\\4");
+            var b = new DomainName(@"a\0924");
+            Assert.AreEqual(a, b);
+        }
     }
 }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -64,6 +64,27 @@ namespace Makaretu.Dns
             Assert.AreEqual(@"my\.example.org", name.ToString());
         }
 
+
+        [TestMethod]
+        public void ImplicitParsingOfString()
+        {
+            DomainName name = @"my\046example.org";
+            Assert.AreEqual(2, name.Labels.Count);
+            Assert.AreEqual("my.example", name.Labels[0]);
+            Assert.AreEqual("org", name.Labels[1]);
+
+            name = @"my\.example.org";
+            Assert.AreEqual(2, name.Labels.Count);
+            Assert.AreEqual("my.example", name.Labels[0]);
+            Assert.AreEqual("org", name.Labels[1]);
+
+            name = @"my.example.org";
+            Assert.AreEqual(3, name.Labels.Count);
+            Assert.AreEqual("my", name.Labels[0]);
+            Assert.AreEqual("example", name.Labels[1]);
+            Assert.AreEqual("org", name.Labels[2]);
+        }
+
         [TestMethod]
         public void FromLabels()
         {
@@ -119,19 +140,37 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
-        public void IsSubdomain()
+        public void IsSubdomainOf()
         {
             var zone = new DomainName("example.org");
-            Assert.IsFalse(zone.IsSubdomain(zone));
-            Assert.IsTrue(new DomainName("a.example.org").IsSubdomain(zone));
-            Assert.IsTrue(new DomainName("a.b.example.org").IsSubdomain(zone));
-            Assert.IsTrue(new DomainName("a.Example.org").IsSubdomain(zone));
-            Assert.IsTrue(new DomainName("a.b.Example.ORG").IsSubdomain(zone));
-            Assert.IsFalse(new DomainName(@"a\.example.org").IsSubdomain(zone));
-            Assert.IsTrue(new DomainName(@"a\.b.example.org").IsSubdomain(zone));
-            Assert.IsTrue(new DomainName(@"a\.b.example.ORG").IsSubdomain(zone));
-            Assert.IsFalse(new DomainName("a.org").IsSubdomain(zone));
-            Assert.IsFalse(new DomainName("a.b.org").IsSubdomain(zone));
+            Assert.IsFalse(zone.IsSubdomainOf(zone));
+            Assert.IsTrue(new DomainName("a.example.org").IsSubdomainOf(zone));
+            Assert.IsTrue(new DomainName("a.b.example.org").IsSubdomainOf(zone));
+            Assert.IsTrue(new DomainName("a.Example.org").IsSubdomainOf(zone));
+            Assert.IsTrue(new DomainName("a.b.Example.ORG").IsSubdomainOf(zone));
+            Assert.IsFalse(new DomainName(@"a\.example.org").IsSubdomainOf(zone));
+            Assert.IsTrue(new DomainName(@"a\.b.example.org").IsSubdomainOf(zone));
+            Assert.IsTrue(new DomainName(@"a\.b.example.ORG").IsSubdomainOf(zone));
+            Assert.IsFalse(new DomainName("a.org").IsSubdomainOf(zone));
+            Assert.IsFalse(new DomainName("a.b.org").IsSubdomainOf(zone));
+        }
+
+        [TestMethod]
+        public void BelongsTo()
+        {
+            var zone = new DomainName("example.org");
+            Assert.IsTrue(zone.BelongsTo(zone));
+            Assert.IsTrue(new DomainName("ExamPLE.Org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName("A.ExamPLE.Org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName("a.example.org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName("a.b.example.org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName("a.Example.org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName("a.b.Example.ORG").BelongsTo(zone));
+            Assert.IsFalse(new DomainName(@"a\.example.org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName(@"a\.b.example.org").BelongsTo(zone));
+            Assert.IsTrue(new DomainName(@"a\.b.example.ORG").BelongsTo(zone));
+            Assert.IsFalse(new DomainName("a.org").BelongsTo(zone));
+            Assert.IsFalse(new DomainName("a.b.org").BelongsTo(zone));
         }
 
         [TestMethod]
@@ -147,5 +186,18 @@ namespace Makaretu.Dns
 
             Assert.IsNull(expected.Parent());
         }
+
+        [TestMethod]
+        public void Joining()
+        {
+            var a = new DomainName(@"foo\.bar");
+            var b = new DomainName("x.y.z");
+            var c = DomainName.Join(a, b);
+            Assert.AreEqual(4, c.Labels.Count);
+            Assert.AreEqual("foo.bar", c.Labels[0]);
+            Assert.AreEqual("x", c.Labels[1]);
+            Assert.AreEqual("y", c.Labels[2]);
+            Assert.AreEqual("z", c.Labels[3]);
+        } 
     }
 }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -272,5 +272,12 @@ namespace Makaretu.Dns
             Assert.AreEqual(@"a\000\092\255z.example", a.ToString());
             Assert.AreEqual(a, new DomainName(a.ToString()));
         }
+
+        [TestMethod]
+        public void FormattedString()
+        {
+            var name = new DomainName(@"foo ~ \.bar-12A.org");
+            Assert.AreEqual(@"foo\032~\032\.bar-12A.org", name.ToString());
+        }
     }
 }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -109,5 +109,13 @@ namespace Makaretu.Dns
             Assert.AreNotEqual(a.GetHashCode(), other1.GetHashCode());
             Assert.AreNotEqual(a.GetHashCode(), other2.GetHashCode());
         }
+
+        [TestMethod]
+        public void ToCanonical()
+        {
+            var a = new DomainName("My.EXAMPLe.ORg");
+            Assert.AreEqual("My.EXAMPLe.ORg", a.ToString());
+            Assert.AreEqual("my.example.org", a.ToCanonical().ToString());
+        }
     }
 }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Makaretu.Dns
+{
+    [TestClass]
+    public class DomainNameTest
+    {
+        [TestMethod]
+        public void Standard()
+        {
+            var name = new DomainName("my.example.org");
+
+            Assert.AreEqual(3, name.Labels.Count);
+            Assert.AreEqual("my", name.Labels[0]);
+            Assert.AreEqual("example", name.Labels[1]);
+            Assert.AreEqual("org", name.Labels[2]);
+
+            Assert.AreEqual("my.example.org", name.ToString());
+        }
+
+        [TestMethod]
+        public void TopLevelDomain()
+        {
+            var name = new DomainName("org");
+
+            Assert.AreEqual(1, name.Labels.Count);
+            Assert.AreEqual("org", name.Labels[0]);
+
+            Assert.AreEqual("org", name.ToString());
+        }
+
+        [TestMethod]
+        public void Root()
+        {
+            var name = new DomainName("");
+
+            Assert.AreEqual(0, name.Labels.Count);
+
+            Assert.AreEqual("", name.ToString());
+        }
+
+        [TestMethod]
+        public void EscapedDotCharacter()
+        {
+            var name = new DomainName(@"my\.example.org");
+
+            Assert.AreEqual(2, name.Labels.Count);
+            Assert.AreEqual("my.example", name.Labels[0]);
+            Assert.AreEqual("org", name.Labels[1]);
+
+            Assert.AreEqual(@"my\.example.org", name.ToString());
+        }
+
+        [TestMethod]
+        public void EscapedDotDigits()
+        {
+            var name = new DomainName(@"my\046example.org");
+
+            Assert.AreEqual(2, name.Labels.Count);
+            Assert.AreEqual("my.example", name.Labels[0]);
+            Assert.AreEqual("org", name.Labels[1]);
+
+            Assert.AreEqual(@"my\.example.org", name.ToString());
+        }
+
+        [TestMethod]
+        public void FromLabels()
+        {
+            var name = new DomainName("my.example", "org");
+
+            Assert.AreEqual(2, name.Labels.Count);
+            Assert.AreEqual("my.example", name.Labels[0]);
+            Assert.AreEqual("org", name.Labels[1]);
+
+            Assert.AreEqual(@"my\.example.org", name.ToString());
+        }
+
+        [TestMethod]
+        public void Equality()
+        {
+            var a = new DomainName(@"my\.example.org");
+            var b = new DomainName("my.example", "org");
+            var c = new DomainName(@"my\046example.org");
+            var other1 = new DomainName("example.org");
+            var other2 = new DomainName("org");
+
+            Assert.AreEqual(a, b);
+            Assert.AreEqual(a, c);
+            Assert.AreNotEqual(a, other1);
+            Assert.AreNotEqual(a, other2);
+        }
+
+        [TestMethod]
+        public void HashEquality()
+        {
+            var a = new DomainName(@"my\.example.org");
+            var b = new DomainName("my.example", "org");
+            var c = new DomainName(@"my\046example.org");
+            var other1 = new DomainName("example.org");
+            var other2 = new DomainName("org");
+
+            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+            Assert.AreEqual(a.GetHashCode(), c.GetHashCode());
+            Assert.AreNotEqual(a.GetHashCode(), other1.GetHashCode());
+            Assert.AreNotEqual(a.GetHashCode(), other2.GetHashCode());
+        }
+    }
+}

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -82,11 +82,13 @@ namespace Makaretu.Dns
             var a = new DomainName(@"my\.example.org");
             var b = new DomainName("my.example", "org");
             var c = new DomainName(@"my\046example.org");
+            var d = new DomainName(@"My\.EXAMPLe.ORg");
             var other1 = new DomainName("example.org");
             var other2 = new DomainName("org");
 
             Assert.AreEqual(a, b);
             Assert.AreEqual(a, c);
+            Assert.AreEqual(a, d);
             Assert.AreNotEqual(a, other1);
             Assert.AreNotEqual(a, other2);
         }
@@ -97,11 +99,13 @@ namespace Makaretu.Dns
             var a = new DomainName(@"my\.example.org");
             var b = new DomainName("my.example", "org");
             var c = new DomainName(@"my\046example.org");
+            var d = new DomainName(@"My\.EXAMPLe.ORg");
             var other1 = new DomainName("example.org");
             var other2 = new DomainName("org");
 
             Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
             Assert.AreEqual(a.GetHashCode(), c.GetHashCode());
+            Assert.AreEqual(a.GetHashCode(), d.GetHashCode());
             Assert.AreNotEqual(a.GetHashCode(), other1.GetHashCode());
             Assert.AreNotEqual(a.GetHashCode(), other2.GetHashCode());
         }

--- a/test/DomainNameTest.cs
+++ b/test/DomainNameTest.cs
@@ -112,6 +112,28 @@ namespace Makaretu.Dns
             Assert.AreEqual(a, d);
             Assert.AreNotEqual(a, other1);
             Assert.AreNotEqual(a, other2);
+            Assert.AreNotEqual(a, null);
+
+            Assert.IsTrue(a == b);
+            Assert.IsTrue(a == c);
+            Assert.IsTrue(a == d);
+            Assert.IsFalse(a == other1);
+            Assert.IsFalse(a == other2);
+            Assert.IsFalse(a == null);
+
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a != c);
+            Assert.IsFalse(a != d);
+            Assert.IsTrue(a != other1);
+            Assert.IsTrue(a != other2);
+            Assert.IsTrue(a != null);
+
+            Assert.IsTrue(a.Equals(b));
+            Assert.IsTrue(a.Equals(c));
+            Assert.IsTrue(a.Equals(d));
+            Assert.IsFalse(a.Equals(other1));
+            Assert.IsFalse(a.Equals(other2));
+            Assert.IsFalse(a.Equals(null));
         }
 
         [TestMethod]

--- a/test/PresentationReaderTest.cs
+++ b/test/PresentationReaderTest.cs
@@ -37,16 +37,16 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
-        public void ReadOctalEscapedString()
+        public void ReadDecimalEscapedString()
         {
-            var reader = new PresentationReader(new StringReader("a\\142c"));
+            var reader = new PresentationReader(new StringReader("a\\098c"));
             Assert.AreEqual("abc", reader.ReadString());
         }
 
         [TestMethod]
-        public void ReadInvalidOctalEscapedString()
+        public void ReadInvalidDecimalEscapedString()
         {
-            var reader = new PresentationReader(new StringReader("a\\200c"));
+            var reader = new PresentationReader(new StringReader("a\\256c"));
             ExceptionAssert.Throws<FormatException>(() => reader.ReadString());
         }
 

--- a/test/PresentationReaderTest.cs
+++ b/test/PresentationReaderTest.cs
@@ -121,6 +121,13 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
+        public void ReadResourceMissingName()
+        {
+            var reader = new PresentationReader(new StringReader("  NS ns1"));
+            ExceptionAssert.Throws<InvalidDataException>(() => reader.ReadResourceRecord());
+        }
+
+        [TestMethod]
         public void ReadResourceWithComment()
         {
             var reader = new PresentationReader(new StringReader("; comment\r\nme A 127.0.0.1"));

--- a/test/PresentationReaderTest.cs
+++ b/test/PresentationReaderTest.cs
@@ -237,6 +237,20 @@ emanon\126.org A 127.0.0.1
         }
 
         [TestMethod]
+        public void ReadResourceWithLeadingEscapedDomainName()
+        {
+            var text = @"\126emanon.org A 127.0.0.1";
+            var reader = new PresentationReader(new StringReader(text));
+            var a = reader.ReadResourceRecord();
+            Assert.AreEqual("~emanon.org", a.Name);
+            Assert.AreEqual(DnsClass.IN, a.Class);
+            Assert.AreEqual(DnsType.A, a.Type);
+            Assert.AreEqual(ResourceRecord.DefaultTTL, a.TTL);
+            Assert.IsInstanceOfType(a, typeof(ARecord));
+            Assert.AreEqual(2, a.Name.Labels.Count);
+        }
+
+        [TestMethod]
         public void ReadZoneFile()
         {
             var text = @"

--- a/test/PresentationReaderTest.cs
+++ b/test/PresentationReaderTest.cs
@@ -149,6 +149,23 @@ $ORIGIN emanon.org. ; no such place\r\n
         }
 
         [TestMethod]
+        public void ReadResourceWithEscapedOrigin()
+        {
+            var text = @"
+$ORIGIN emanon\.org. ; no such place\r\n
+@ PTR localhost
+";
+            var reader = new PresentationReader(new StringReader(text));
+            var resource = reader.ReadResourceRecord();
+            Assert.AreEqual(@"emanon\.org", resource.Name);
+            Assert.AreEqual(DnsClass.IN, resource.Class);
+            Assert.AreEqual(DnsType.PTR, resource.Type);
+            Assert.AreEqual(ResourceRecord.DefaultTTL, resource.TTL);
+            Assert.IsInstanceOfType(resource, typeof(PTRRecord));
+            Assert.AreEqual(1, resource.Name.Labels.Count);
+        }
+
+        [TestMethod]
         public void ReadResourceWithTTL()
         {
             var text = @"
@@ -185,6 +202,31 @@ emanon.org A 127.0.0.1
             Assert.AreEqual(DnsType.AAAA, aaaa.Type);
             Assert.AreEqual(ResourceRecord.DefaultTTL, aaaa.TTL);
             Assert.IsInstanceOfType(aaaa, typeof(AAAARecord));
+        }
+
+        [TestMethod]
+        public void ReadResourceWithPreviousEscapedDomain()
+        {
+            var text = @"
+emanon\126.org A 127.0.0.1
+           AAAA ::1
+";
+            var reader = new PresentationReader(new StringReader(text));
+            var a = reader.ReadResourceRecord();
+            Assert.AreEqual("emanon~.org", a.Name);
+            Assert.AreEqual(DnsClass.IN, a.Class);
+            Assert.AreEqual(DnsType.A, a.Type);
+            Assert.AreEqual(ResourceRecord.DefaultTTL, a.TTL);
+            Assert.IsInstanceOfType(a, typeof(ARecord));
+            Assert.AreEqual(2, a.Name.Labels.Count);
+
+            var aaaa = reader.ReadResourceRecord();
+            Assert.AreEqual("emanon~.org", aaaa.Name);
+            Assert.AreEqual(DnsClass.IN, aaaa.Class);
+            Assert.AreEqual(DnsType.AAAA, aaaa.Type);
+            Assert.AreEqual(ResourceRecord.DefaultTTL, aaaa.TTL);
+            Assert.IsInstanceOfType(aaaa, typeof(AAAARecord));
+            Assert.AreEqual(2, a.Name.Labels.Count);
         }
 
         [TestMethod]
@@ -390,5 +432,16 @@ mail3         IN  A     192.0.2.5             ; IPv4 address for mail3.example.c
             Assert.AreEqual(expected, reader.ReadDateTime());
             Assert.AreEqual(expected, reader.ReadDateTime());
         }
+
+        [TestMethod]
+        public void ReadDomainName_Escaped()
+        {
+            var foo = new DomainName("foo.com");
+            var drSmith = new DomainName(@"dr\. smith.com");
+            var reader = new PresentationReader(new StringReader(@"dr\.\032smith.com foo.com"));
+            Assert.AreEqual(drSmith, reader.ReadDomainName());
+            Assert.AreEqual(foo, reader.ReadDomainName());
+        }
+
     }
 }

--- a/test/PresentationWriterTest.cs
+++ b/test/PresentationWriterTest.cs
@@ -75,6 +75,20 @@ namespace Makaretu.Dns
             writer.WriteString("alpha.com");
             writer.WriteString("omega.com", appendSpace: false);
             Assert.AreEqual("alpha.com omega.com", text.ToString());
+
+            text = new StringWriter();
+            writer = new PresentationWriter(text);
+            writer.WriteDomainName(new DomainName("alpha.com"), false);
+            Assert.AreEqual("alpha.com", text.ToString());
+        }
+
+        [TestMethod]
+        public void WriteDomainName_Escaped()
+        {
+            var text = new StringWriter();
+            var writer = new PresentationWriter(text);
+            writer.WriteDomainName(new DomainName(@"dr\. smith.com"), false);
+            Assert.AreEqual(@"dr\.\032smith.com", text.ToString());
         }
 
         [TestMethod]

--- a/test/Resolving/CatalogTest.cs
+++ b/test/Resolving/CatalogTest.cs
@@ -259,7 +259,7 @@ mail3         IN  A     192.0.2.5             ; IPv4 address for mail3.example.c
                 AddressRecord.Create("example", IPAddress.Loopback)
             };
 
-            var expected = new string[]
+            var expected = new DomainName[]
             {
                 "example", "a.example", "yljkjljk.a.example",
                 "Z.a.example", "zABC.a.EXAMPLE", "z.example",

--- a/test/Resolving/NameServerTest.cs
+++ b/test/Resolving/NameServerTest.cs
@@ -365,17 +365,19 @@ namespace Makaretu.Dns.Resolving
         [TestMethod]
         public async Task EscapedDotDomainName()
         {
-            var catalog = new Catalog();
-            catalog.Add(new ARecord
+            var catalog = new Catalog
             {
-                Name = "a.b",
-                Address = IPAddress.Parse("127.0.0.2")
-            });
-            catalog.Add(new ARecord
-            {
-                Name = @"a\.b",
-                Address = IPAddress.Parse("127.0.0.3")
-            });
+                new ARecord
+                {
+                    Name = "a.b",
+                    Address = IPAddress.Parse("127.0.0.2")
+                },
+                new ARecord
+                {
+                    Name = @"a\.b",
+                    Address = IPAddress.Parse("127.0.0.3")
+                }
+            };
             var resolver = new NameServer { Catalog = catalog };
 
             var request = new Message();
@@ -396,17 +398,19 @@ namespace Makaretu.Dns.Resolving
         [TestMethod]
         public async Task RoundTrip_EscapedDotDomainName()
         {
-            var catalog = new Catalog();
-            catalog.Add(new ARecord
+            var catalog = new Catalog
             {
-                Name = "a.b",
-                Address = IPAddress.Parse("127.0.0.2")
-            });
-            catalog.Add(new ARecord
-            {
-                Name = @"a\.b",
-                Address = IPAddress.Parse("127.0.0.3")
-            });
+                new ARecord
+                {
+                    Name = "a.b",
+                    Address = IPAddress.Parse("127.0.0.2")
+                },
+                new ARecord
+                {
+                    Name = @"a\.b",
+                    Address = IPAddress.Parse("127.0.0.3")
+                }
+            };
             var resolver = new NameServer { Catalog = catalog };
 
             var request = new Message();

--- a/test/Resolving/NameServerTest.cs
+++ b/test/Resolving/NameServerTest.cs
@@ -361,5 +361,65 @@ namespace Makaretu.Dns.Resolving
 
             Assert.AreEqual(0, response.AdditionalRecords.Count);
         }
+
+        [TestMethod]
+        public async Task EscapedDotDomainName()
+        {
+            var catalog = new Catalog();
+            catalog.Add(new ARecord
+            {
+                Name = "a.b",
+                Address = IPAddress.Parse("127.0.0.2")
+            });
+            catalog.Add(new ARecord
+            {
+                Name = @"a\.b",
+                Address = IPAddress.Parse("127.0.0.3")
+            });
+            var resolver = new NameServer { Catalog = catalog };
+
+            var request = new Message();
+            request.Questions.Add(new Question { Name = "a.b", Type = DnsType.A });
+            var response = await resolver.ResolveAsync(request);
+            Assert.AreEqual(MessageStatus.NoError, response.Status);
+            var answer = response.Answers.OfType<ARecord>().First();
+            Assert.AreEqual("127.0.0.2", answer.Address.ToString());
+
+            request = new Message();
+            request.Questions.Add(new Question { Name = @"a\.b", Type = DnsType.A });
+            response = await resolver.ResolveAsync(request);
+            Assert.AreEqual(MessageStatus.NoError, response.Status);
+            answer = response.Answers.OfType<ARecord>().First();
+            Assert.AreEqual("127.0.0.3", answer.Address.ToString());
+        }
+
+        [TestMethod]
+        public async Task RoundTrip_EscapedDotDomainName()
+        {
+            var catalog = new Catalog();
+            catalog.Add(new ARecord
+            {
+                Name = "a.b",
+                Address = IPAddress.Parse("127.0.0.2")
+            });
+            catalog.Add(new ARecord
+            {
+                Name = @"a\.b",
+                Address = IPAddress.Parse("127.0.0.3")
+            });
+            var resolver = new NameServer { Catalog = catalog };
+
+            var request = new Message();
+            request.Questions.Add(new Question { Name = @"a\.b", Type = DnsType.A });
+            var bin = request.ToByteArray();
+            var r1 = new Message();
+            r1.Read(bin);
+
+            var response = await resolver.ResolveAsync(r1);
+            Assert.AreEqual(MessageStatus.NoError, response.Status);
+            var answer = response.Answers.OfType<ARecord>().First();
+            Assert.AreEqual("127.0.0.3", answer.Address.ToString());
+
+        }
     }
 }

--- a/test/Resolving/NodeTest.cs
+++ b/test/Resolving/NodeTest.cs
@@ -16,7 +16,7 @@ namespace Makaretu.Dns.Resolving
         {
             var node = new Node();
 
-            Assert.AreEqual("", node.Name);
+            Assert.AreEqual(DomainName.Root, node.Name);
             Assert.AreEqual(0, node.Resources.Count);
             Assert.AreEqual("", node.ToString());
         }

--- a/test/ResourceRecordTest.cs
+++ b/test/ResourceRecordTest.cs
@@ -218,8 +218,10 @@ namespace Makaretu.Dns
         public void RDATA_Underflow()
         {
             // CNAME with extra byte.
-            var ms = new MemoryStream(Convert.FromBase64String("A2ZvbwAABQABAAFRgAAKB3Vua25vd24A/w=="));
-            ms.Position = 0;
+            var ms = new MemoryStream(Convert.FromBase64String("A2ZvbwAABQABAAFRgAAKB3Vua25vd24A/w=="))
+            {
+                Position = 0
+            };
             ExceptionAssert.Throws<InvalidDataException>(() =>
             {
                 var _ = new ResourceRecord().Read(ms);

--- a/test/WireReaderWriterTest.cs
+++ b/test/WireReaderWriterTest.cs
@@ -54,6 +54,36 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
+        public void Write_DomainName()
+        {
+            var ms = new MemoryStream();
+            var writer = new WireWriter(ms);
+            writer.WriteDomainName("a.b");
+
+            ms.Position = 0;
+            Assert.AreEqual(1, ms.ReadByte(), "length of 'a'");
+            Assert.AreEqual('a', (char)ms.ReadByte());
+            Assert.AreEqual(1, ms.ReadByte(), "length of 'b'");
+            Assert.AreEqual('b', (char)ms.ReadByte());
+            Assert.AreEqual(0, ms.ReadByte(), "trailing nul");
+        }
+
+        [TestMethod]
+        public void Write_EscapedDomainName()
+        {
+            var ms = new MemoryStream();
+            var writer = new WireWriter(ms);
+            writer.WriteDomainName(@"a\.b");
+
+            ms.Position = 0;
+            Assert.AreEqual(3, ms.ReadByte(), "length of 'a.b'");
+            Assert.AreEqual('a', (char)ms.ReadByte());
+            Assert.AreEqual('.', (char)ms.ReadByte());
+            Assert.AreEqual('b', (char)ms.ReadByte());
+            Assert.AreEqual(0, ms.ReadByte(), "trailing nul");
+        }
+
+        [TestMethod]
         public void BufferOverflow_Byte()
         {
             var ms = new MemoryStream(new byte[0]);
@@ -142,11 +172,25 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
-        public void NullDomainName()
+        public void NullDomainName_String()
         {
             var ms = new MemoryStream();
             var writer = new WireWriter(ms);
-            writer.WriteDomainName(null);
+            writer.WriteDomainName((string) null);
+            writer.WriteString("abc");
+
+            ms.Position = 0;
+            var reader = new WireReader(ms);
+            Assert.AreEqual("", reader.ReadDomainName());
+            Assert.AreEqual("abc", reader.ReadString());
+        }
+
+        [TestMethod]
+        public void NullDomainName_Class()
+        {
+            var ms = new MemoryStream();
+            var writer = new WireWriter(ms);
+            writer.WriteDomainName((DomainName)null);
             writer.WriteString("abc");
 
             ms.Position = 0;

--- a/test/WireReaderWriterTest.cs
+++ b/test/WireReaderWriterTest.cs
@@ -200,6 +200,20 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
+        public void Read_EscapedDotDomainName()
+        {
+            var domainName = @"a\.b";
+            var ms = new MemoryStream();
+            var writer = new WireWriter(ms);
+            writer.WriteDomainName(domainName);
+
+            ms.Position = 0;
+            var reader = new WireReader(ms);
+            var name = reader.ReadDomainName();
+            Assert.AreEqual(domainName, name);
+        }
+
+        [TestMethod]
         public void Bitmap()
         {
             // From https://tools.ietf.org/html/rfc3845#section-2.3


### PR DESCRIPTION
This is a **breaking change**.  A domain name is now a first class object not just a string.  This is needed to handle cases when a domain name label contains a backslash or a dot.